### PR TITLE
CLOUD-594-close-config-files-after-saving

### DIFF
--- a/aqovia-nuget-update.ps1
+++ b/aqovia-nuget-update.ps1
@@ -177,6 +177,7 @@
                             $w = [System.Xml.XmlWriter]::Create($configFile, $settings)
                             $xmlFile.PreserveWhitespace = $true
                             $xmlFile.Save($w)
+			    $w.Close()
                             $hasUpdate = $true
                         }
                     }
@@ -197,6 +198,7 @@
                             $w = [System.Xml.XmlWriter]::Create($configFile, $settings)
                             $xmlFile.PreserveWhitespace = $true
                             $xmlFile.Save($w)
+			    $w.Close()
                             $hasUpdate = $true
                         }
                     }


### PR DESCRIPTION
Close config files after saving, so that they are not write-access locked